### PR TITLE
docs: refactor docs for VMarker component from lng-lat to coordinates prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ bun add @geoql/v-maplibre maplibre-gl @deck.gl/{core,layers,mapbox,aggregation-l
 
 <template>
   <VMap :options="mapOptions" style="height: 500px">
-    <VMarker :lng-lat="[-74.5, 40]"></VMarker>
+    <VMarker :coordinates="[-74.5, 40]"></VMarker>
   </VMap>
 </template>
 ```

--- a/apps/docs/AGENTS.md
+++ b/apps/docs/AGENTS.md
@@ -67,7 +67,7 @@ This is an info alert.
 
 ```vue [With Marker]
 <VMap :options="mapOptions">
-  <VMarker :lng-lat="[0, 0]" />
+  <VMarker :coordinates="[0, 0]" />
 </VMap>
 ```
 ::
@@ -111,7 +111,7 @@ Brief description of what the component does.
 ::code-group
 ```vue [Template]
 <VMap :options="mapOptions" @load="onMapLoad">
-  <VMarker :lng-lat="[-74.5, 40]" />
+  <VMarker :coordinates="[-74.5, 40]" />
 </VMap>
 ```
 

--- a/apps/docs/content/1.guide/2.examples.md
+++ b/apps/docs/content/1.guide/2.examples.md
@@ -25,7 +25,7 @@ description: Practical examples for using v-maplibre components
 
 <template>
   <VMap :options="mapOptions" style="height: 500px">
-    <VMarker :lng-lat="markerPosition"></VMarker>
+    <VMarker :coordinates="markerPosition"></VMarker>
   </VMap>
 </template>
 ```
@@ -96,10 +96,10 @@ description: Practical examples for using v-maplibre components
 
 <template>
   <VMap :options="mapOptions" style="height: 500px">
-    <VMarker :lng-lat="markerPosition" @click="showPopup = true"></VMarker>
+    <VMarker :coordinates="markerPosition" @click="showPopup = true"></VMarker>
     <VPopup
       v-if="showPopup"
-      :lng-lat="markerPosition"
+      :coordinates="markerPosition"
       @close="showPopup = false"
     >
       <div>

--- a/apps/docs/content/2.components/1.map.md
+++ b/apps/docs/content/2.components/1.map.md
@@ -111,7 +111,7 @@ The default slot is used to nest child components like markers, popups, layers, 
 
 ```vue
 <VMap :options="mapOptions">
-  <VMarker :lng-lat="[0, 0]" />
+  <VMarker :coordinates="[0, 0]" />
   <VLayerMaplibreGeojson :source="source" :layer="layer" />
   <VControlNavigation />
 </VMap>

--- a/apps/docs/content/2.components/2.markers.md
+++ b/apps/docs/content/2.components/2.markers.md
@@ -20,14 +20,14 @@ description: Add interactive markers to your map
 
 <template>
   <VMap :options="mapOptions" style="height: 500px">
-    <VMarker :lng-lat="markerPosition"></VMarker>
+    <VMarker :coordinates="markerPosition"></VMarker>
   </VMap>
 </template>
 ```
 
 ## Props
 
-### lngLat
+### coordinates
 
 - **Type:** `LngLatLike`
 - **Required:** `true`
@@ -40,10 +40,10 @@ The geographic location of the marker. Can be:
 
 ```vue
 <!-- Object notation -->
-<VMarker :lng-lat="{ lng: -74.5, lat: 40 }"></VMarker>
+<VMarker :coordinates="{ lng: -74.5, lat: 40 }"></VMarker>
 
 <!-- Array notation -->
-<VMarker :lng-lat="[-74.5, 40]"></VMarker>
+<VMarker :coordinates="[-74.5, 40]"></VMarker>
 ```
 
 ### draggable
@@ -55,7 +55,7 @@ The geographic location of the marker. Can be:
 Make the marker draggable.
 
 ```vue
-<VMarker :lng-lat="position" draggable @dragend="handleDragEnd"></VMarker>
+<VMarker :coordinates="position" draggable @dragend="handleDragEnd"></VMarker>
 ```
 
 ### options
@@ -75,7 +75,7 @@ Common options:
 
 ```vue
 <VMarker
-  :lng-lat="position"
+  :coordinates="position"
   :options="{
     color: '#FF0000',
     rotation: 45,
@@ -91,7 +91,7 @@ Common options:
 Emitted when the marker is clicked.
 
 ```vue
-<VMarker :lng-lat="position" @click="handleMarkerClick"></VMarker>
+<VMarker :coordinates="position" @click="handleMarkerClick"></VMarker>
 ```
 
 ### @dragstart
@@ -99,7 +99,7 @@ Emitted when the marker is clicked.
 Emitted when marker dragging starts.
 
 ```vue
-<VMarker :lng-lat="position" draggable @dragstart="handleDragStart"></VMarker>
+<VMarker :coordinates="position" draggable @dragstart="handleDragStart"></VMarker>
 ```
 
 ### @drag
@@ -107,7 +107,7 @@ Emitted when marker dragging starts.
 Emitted continuously while dragging.
 
 ```vue
-<VMarker :lng-lat="position" draggable @drag="handleDrag"></VMarker>
+<VMarker :coordinates="position" draggable @drag="handleDrag"></VMarker>
 ```
 
 ### @dragend
@@ -115,7 +115,7 @@ Emitted continuously while dragging.
 Emitted when marker dragging ends.
 
 ```vue
-<VMarker :lng-lat="position" draggable @dragend="handleDragEnd"></VMarker>
+<VMarker :coordinates="position" draggable @dragend="handleDragEnd"></VMarker>
 ```
 
 ## Slots
@@ -125,7 +125,7 @@ Emitted when marker dragging ends.
 Customize marker HTML content.
 
 ```vue
-<VMarker :lng-lat="position">
+<VMarker :coordinates="position">
   <div class="custom-marker">
     <img src="/marker-icon.png" alt="Custom marker" />
   </div>
@@ -137,7 +137,7 @@ Customize marker HTML content.
 ### Custom Color
 
 ```vue
-<VMarker :lng-lat="[-74.5, 40]" :options="{ color: '#FF5733' }"></VMarker>
+<VMarker :coordinates="[-74.5, 40]" :options="{ color: '#FF5733' }"></VMarker>
 ```
 
 ### Draggable Marker
@@ -158,7 +158,7 @@ Customize marker HTML content.
 
 <template>
   <VMap :options="mapOptions" style="height: 500px">
-    <VMarker :lng-lat="position" draggable @dragend="handleDragEnd"></VMarker>
+    <VMarker :coordinates="position" draggable @dragend="handleDragEnd"></VMarker>
   </VMap>
 </template>
 ```
@@ -174,7 +174,7 @@ Customize marker HTML content.
 
 <template>
   <VMap :options="mapOptions" style="height: 500px">
-    <VMarker :lng-lat="position">
+    <VMarker :coordinates="position">
       <div class="custom-marker">
         <div class="marker-pin"></div>
         <div class="marker-label">Custom Pin</div>
@@ -231,7 +231,7 @@ Customize marker HTML content.
     <VMarker
       v-for="location in locations"
       :key="location.id"
-      :lng-lat="[location.lng, location.lat]"
+      :coordinates="[location.lng, location.lat]"
       :options="{ color: location.color }"
       @click="() => console.log('Clicked:', location.name)"
     ></VMarker>

--- a/apps/mapcn-vue/AGENTS.md
+++ b/apps/mapcn-vue/AGENTS.md
@@ -90,7 +90,7 @@ import type { RoutePoint, MapState } from '~/types/map';
 
 <template>
   <VMap :options="mapOptions">
-    <VMarker :lng-lat="[-74.5, 40]" />
+    <VMarker :coordinates="[-74.5, 40]" />
     <VControlNavigation position="top-right" />
   </VMap>
 </template>
@@ -590,7 +590,7 @@ npx shadcn-vue@latest add https://mapcn-vue.geoql.in/r/map
 
 <template>
   <VMap :options="mapOptions" class="h-[500px] rounded-lg">
-    <VMarker :lng-lat="[-74.5, 40]" />
+    <VMarker :coordinates="[-74.5, 40]" />
     <VControlNavigation position="top-right" />
     <VControlScale position="bottom-left" />
   </VMap>

--- a/apps/mapcn-vue/app/pages/examples/weather-dashboard.vue
+++ b/apps/mapcn-vue/app/pages/examples/weather-dashboard.vue
@@ -66,7 +66,7 @@
 
               <template>
                 <VMap :options="mapOptions" class="h-125 w-full">
-                  <VMarker v-for="city in citiesWeather" :key="city.name" :lng-lat="[city.lon, city.lat]">
+                  <VMarker v-for="city in citiesWeather" :key="city.name" :coordinates="[city.lon, city.lat]">
                     <div class="rounded-full bg-background/90 px-2 py-1 text-xs font-bold shadow">
                       {{ Math.round(city.current.temperature_2m) }}°
                     </div>

--- a/apps/mapcn-vue/content/docs/2.installation.md
+++ b/apps/mapcn-vue/content/docs/2.installation.md
@@ -80,7 +80,7 @@ Once installed, you can use the components in your Vue templates:
 <template>
   <Map :options="mapOptions" class="h-125">
     <MapControls />
-    <MapMarker :lng-lat="[-74.006, 40.7128]" />
+    <MapMarker :coordinates="[-74.006, 40.7128]" />
   </Map>
 </template>
 ```

--- a/bun.lock
+++ b/bun.lock
@@ -114,7 +114,7 @@
     },
     "packages/v-maplibre": {
       "name": "@geoql/v-maplibre",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "dependencies": {
         "maplibre-gl": "^5.22.0",
         "pmtiles": "^4.4.0",

--- a/packages/mapcn-vue/README.md
+++ b/packages/mapcn-vue/README.md
@@ -134,7 +134,7 @@ LiDAR point cloud visualization.
 <template>
   <Map :center="[-74.006, 40.7128]" :zoom="12" class="h-125 rounded-lg">
     <MapControls show-navigation show-scale></MapControls>
-    <MapMarker :lng-lat="[-74.006, 40.7128]"></MapMarker>
+    <MapMarker :coordinates="[-74.006, 40.7128]"></MapMarker>
   </Map>
 </template>
 ```

--- a/packages/mapcn-vue/registry/new-york/map/MapMarker.vue
+++ b/packages/mapcn-vue/registry/new-york/map/MapMarker.vue
@@ -37,14 +37,14 @@
 
 <template>
   <VMarker
-    :lng-lat="props.lngLat"
+    :coordinates="props.lngLat"
     :draggable="props.draggable"
     :anchor="props.anchor"
     :offset="props.offset"
     :color="props.color"
     :scale="props.scale"
     :class="props.class"
-    @click="(e) => emit('click', e)"
+    @click="(e: MouseEvent) => emit('click', e)"
     @dragstart="(e) => emit('dragstart', e)"
     @drag="(e) => emit('drag', e)"
     @dragend="(e) => emit('dragend', e)"

--- a/packages/v-maplibre/README.md
+++ b/packages/v-maplibre/README.md
@@ -73,7 +73,7 @@ bun add maplibre-gl-wind
 
 <template>
   <VMap :options="mapOptions" style="height: 500px">
-    <VMarker :lng-lat="[-74.5, 40]"></VMarker>
+    <VMarker :coordinates="[-74.5, 40]"></VMarker>
   </VMap>
 </template>
 ```

--- a/packages/v-maplibre/test/markers/VMarker.test.ts
+++ b/packages/v-maplibre/test/markers/VMarker.test.ts
@@ -24,7 +24,7 @@ describe('VMarker', () => {
         options: defaultMapOptions,
       },
       slots: {
-        default: `<VMarker :lng-lat="[0, 0]" />`,
+        default: `<VMarker :coordinates="[0, 0]" />`,
       },
       global: {
         components: {
@@ -43,7 +43,7 @@ describe('VMarker', () => {
       },
       slots: {
         default: {
-          template: '<VMarker :lng-lat="{ lng: 10, lat: 20 }" />',
+          template: '<VMarker :coordinates="{ lng: 10, lat: 20 }" />',
           components: { VMarker },
         },
       },
@@ -59,7 +59,7 @@ describe('VMarker', () => {
       },
       slots: {
         default: {
-          template: '<VMarker :lng-lat="[10, 20]" />',
+          template: '<VMarker :coordinates="[10, 20]" />',
           components: { VMarker },
         },
       },
@@ -75,7 +75,7 @@ describe('VMarker', () => {
       },
       slots: {
         default: {
-          template: '<VMarker :lng-lat="[0, 0]" draggable />',
+          template: '<VMarker :coordinates="[0, 0]" draggable />',
           components: { VMarker },
         },
       },
@@ -92,7 +92,7 @@ describe('VMarker', () => {
       slots: {
         default: {
           template:
-            '<VMarker :lng-lat="[0, 0]" :options="{ color: \'#FF0000\' }" />',
+            '<VMarker :coordinates="[0, 0]" :options="{ color: \'#FF0000\' }" />',
           components: { VMarker },
         },
       },
@@ -111,7 +111,7 @@ describe('VMarker', () => {
       slots: {
         default: {
           template: `
-            <VMarker :lng-lat="[0, 0]">
+            <VMarker :coordinates="[0, 0]">
               <div class="custom-marker">Custom</div>
             </VMarker>
           `,


### PR DESCRIPTION
Changed the docs for the `VMarker` component from using `:lng-lat` as a prop to `:coordinates`, which matches its current implementation.