### PR TITLE
fix(mapcn-vue): bake r2 assets base into the ssr runtime config

### DIFF
--- a/apps/mapcn-vue/nuxt.config.ts
+++ b/apps/mapcn-vue/nuxt.config.ts
@@ -131,10 +131,14 @@ export default defineNuxtConfig({
         process.env.NUXT_PUBLIC_OPENWEATHERMAP_API_KEY ??
         '385df3d81f3a89c1c99c115735540c6d',
       // Base URL of the R2 bucket hosting geolith-generated demo assets
-      // (Gaussian splats, 3D Tiles tilesets, Terrain-RGB PMTiles). Injected
-      // at build time via NUXT_PUBLIC_R2_ASSETS_BASE (GH secret) so the
-      // bucket can be rotated without a code change.
-      r2AssetsBase: '',
+      // (Gaussian splats, 3D Tiles tilesets, Terrain-RGB PMTiles). Baked at
+      // build time from NUXT_PUBLIC_R2_ASSETS_BASE (GH secret) so the bucket
+      // can be rotated without a code change. Must read process.env HERE:
+      // /examples/* is worker-routed (assets.run_worker_first), so those
+      // pages are SSR'd with the server bundle's baked default — a static ''
+      // would ship empty asset URLs even though prerendered payloads got the
+      // value (that was the bug behind broken live splat/3d-tiles demos).
+      r2AssetsBase: process.env.NUXT_PUBLIC_R2_ASSETS_BASE ?? '',
       library: {
         version: libraryPkg.version,
         releasedAt: LIBRARY_RELEASED_AT,


### PR DESCRIPTION
## Why the merged #141 demos were still broken on mapcn-vue.geoql.in

The Aug 5 deploy of #141 succeeded (version d9b69696, custom domain attached) and its CI artifact was correct — `grep r2AssetsBase` in the prerendered HTML shows the real bucket URL baked in.

But the live pages served `r2AssetsBase:""`.

**Root cause:** `/examples/*` is in `assets.run_worker_first`, so real-user requests never touch the prerendered HTML — they're SSR'd by the worker at request time. `runtimeConfig.public.r2AssetsBase` was a static `''` in `nuxt.config.ts`; the `NUXT_PUBLIC_R2_ASSETS_BASE` env only reached the *prerender* pass (env-driven runtime-config override during build), not the server bundle's baked defaults. Same build, two different outputs: static artifact correct, worker SSR empty. The splat/3d-tiles pages then fetched no assets at all.

**Fix:** read `process.env.NUXT_PUBLIC_R2_ASSETS_BASE` in the config default, exactly like the sibling public keys (`openweathermapApiKey`, OpenPanel client id) already do.

**Verified:** rebuilt with the secret exported → `wrangler dev` on the real `.output/server/wrangler.json` → `curl /examples/splat` now serves `r2AssetsBase:"https://samples.geolith.app"` through the worker-routed SSR path (the exact path production uses).

After merge, the pipeline deploy will pick this up and the live demos will get their asset URLs.