### PR TITLE
fix: scope unsafe-eval csp to lidar-copc route

### DIFF
--- a/apps/mapcn-vue/nuxt.config.ts
+++ b/apps/mapcn-vue/nuxt.config.ts
@@ -338,6 +338,39 @@ export default defineNuxtConfig({
   routeRules: {
     // /docs has no index page — send crawlers and humans to the first doc.
     '/docs': { redirect: { to: '/docs/introduction', statusCode: 301 } },
+    // COPC LiDAR streaming decodes LAZ with laz-perf, whose Emscripten glue
+    // builds its dynCall trampolines with `new Function(...)` — blocked by the
+    // site-wide A+ CSP, which omits 'unsafe-eval' (only 'wasm-unsafe-eval' is
+    // allowed, for shiki). laz-perf ships no non-eval path (the CSP-clean
+    // laz_rs_wasm decoder is not selectable through the public API), so scope
+    // 'unsafe-eval' to just this one route. Both layers are overridden to match
+    // the dual-layer setup above: `security` patches the runtime nonce CSP that
+    // the worker serves this page with (the document policy that governs the
+    // eval), and `headers` patches the static _headers fallback. Every other
+    // route keeps the strict nonce/strict-dynamic policy untouched.
+    '/examples/lidar-copc': {
+      security: {
+        headers: {
+          contentSecurityPolicy: {
+            'script-src': [
+              "'self'",
+              'https:',
+              "'unsafe-inline'",
+              "'strict-dynamic'",
+              "'nonce-{{nonce}}'",
+              "'unsafe-eval'",
+              "'wasm-unsafe-eval'",
+            ],
+          },
+        },
+      },
+      headers: {
+        'Content-Security-Policy':
+          "base-uri 'none'; connect-src 'self' https: data: blob:; font-src 'self' https: data:; form-action 'self'; frame-ancestors 'none'; frame-src 'self'; img-src 'self' data: blob: https:; media-src 'self' data: blob:; object-src 'none'; script-src 'self' https: 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval'; style-src 'self' https: 'unsafe-inline'; worker-src 'self' blob:; upgrade-insecure-requests",
+        'Permissions-Policy':
+          'camera=(), display-capture=(), fullscreen=(self), geolocation=(), microphone=()',
+      },
+    },
     '/**': {
       headers: {
         'Content-Security-Policy':


### PR DESCRIPTION
## Problem

The COPC LiDAR streaming demo at [`/examples/lidar-copc`](https://mapcn-vue.geoql.in/examples/lidar-copc) is broken — no points stream. The browser console shows:

> Failed to load: Evaluating a string as JavaScript violates the following Content Security Policy directive because 'unsafe-eval' is not an allowed source of script: `script-src 'self' https: 'unsafe-inline' 'strict-dynamic' 'nonce-…' 'wasm-unsafe-eval'`.

## Root cause

`maplibre-gl-lidar` decodes COPC/LAZ with **`laz-perf`**, an Emscripten (C++→WASM) module. Emscripten's JS glue builds its dynamic-call trampolines (`createNamedFunction`, `makeDynCaller`, `dynCall_*`) with **`new Function(...)`**. The WASM binary itself is fine under `'wasm-unsafe-eval'`, but `new Function` requires **`'unsafe-eval'`** — which the site-wide A+ CSP deliberately omits. So the decoder never initialises and zero points decode.

The library ships a second, CSP-clean Rust decoder (`laz_rs_wasm_bg.wasm`) but it is **not selectable through the public API** (the COPC loader chunk hard-references `LazPerf` ×53, `laz_rs` ×0), so there is no non-eval path to switch to.

## Fix

Scope `'unsafe-eval'` to **only** `/examples/lidar-copc` via a route rule, patching **both** CSP layers this app uses:
- `security.headers.contentSecurityPolicy.script-src` — the runtime **nonce CSP** that nuxt-security serves this worker-routed page with (the document policy that actually governs the eval). `defuReplaceArray` replaces the array, so the full global list is repeated + `'unsafe-eval'`.
- `headers['Content-Security-Policy']` — the static `_headers` fallback for asset-served responses.

Every other route keeps the strict `nonce` / `strict-dynamic` A+ policy untouched.

## Verification

Dev server, headless Chromium (Playwright):

- **CSP header, `/examples/lidar-copc`:** `script-src … 'strict-dynamic' 'nonce-…' 'unsafe-eval' 'wasm-unsafe-eval'` ✅
- **CSP header, `/examples/basic` (control):** `script-src … 'strict-dynamic' 'nonce-…' 'wasm-unsafe-eval'` — no `unsafe-eval`, A+ intact ✅
- **Functional:** the `unsafe-eval` console violation is **gone**; `Point cloud loaded` fires; **10,653,336 points** decode (full Autzen dataset); deck.gl render canvas + lidar colorbar/profile canvases present ✅

Deploys to production on merge (push to `main` → pipeline → CI → deploy-mapcn, with the R2/OpenPanel/maps.guru build secrets).